### PR TITLE
Training insert with params

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Per executar el programa mitjançant un paquet jar ens trobarem les següents op
 
 ```{java}
 usage: spamizer
- -c <arg>   Receives 2 parameters, A directory with spam mails and a
+ -c <arg>   Usage : -c <spamDir> <hamDir> [-n <int>]
+            Receives 2 parameters, A directory with spam mails and a
             directory with ham mails. A calculation for values phi and k
             will be done using a selection for the mails set. The
             selection will be k-fold cross-validation and the heuristic
@@ -78,6 +79,8 @@ Si es pretén llegir un conjunt finit de correus des d'un directori s'ha d'espec
 El mode validation reb un conjunt finit de correus procedents d'un directori que s'especifica per paràmetre. Aquest procediment exporta els resultats dels correus llegits en el format TP, FP, TN i FN per tots els correus inserits. 
 
 ### Mode Phi and K Evaluation
+
+Reb dos directoris per aquest ordre <dirSpam> <dirHam> en cas que detecti que no els reb o que per el nom del directori els reb malament llençarà una excepció. 
 
 El paràmetre -c realitza una execució per el càlcul dels valors phi i k. S'utilitza el mètode heurístic High Climbing amb random restarts per ajustar-los i el procés de selecció dels correus electrònics és mitjançant un k-fold cross-validation (selecció aleatòria). Reb 2 directoris, el directori spam i el directori ham per aquest ordre. Requereix del paràmetre -n per estipular un nombre finit d'execucions, en cas que no se li assigni el paràmetre -n s'executarà només una vegada. 
 

--- a/src/spamizer/Application.java
+++ b/src/spamizer/Application.java
@@ -4,13 +4,18 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.ParseException;
 import spamizer.MLCore.DirectoryMailReader;
+import spamizer.MLCore.KFoldCrossValidationSelection;
 import spamizer.MLCore.StanfordCoreNLPFilter;
 import spamizer.configurations.ApplicationOptions;
 import spamizer.entity.Database;
 import spamizer.exceptions.BadArgumentsException;
 
+import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import spamizer.MLCore.Trainer;
+import spamizer.exceptions.BadPercentageException;
+import spamizer.exceptions.CustomException;
+import spamizer.interfaces.Reader;
 
 import java.sql.SQLException;
 import java.util.Random;
@@ -19,6 +24,9 @@ import java.util.Random;
  * Application Spamizer
  */
 public class Application  {
+
+    public static int MIN_PERC = 5;
+    public static int MAX_PERC = 15;
 
     public static Random random;
 
@@ -31,57 +39,109 @@ public class Application  {
      * 3- Validem si s'afegeix la opció.
      * 4- Persistim la bd en memòria a un fitxer local si s'afegeix la opció.
      */
-    public static void start(CommandLine options) throws BadArgumentsException, SQLException, ClassNotFoundException {
+    public static void start(CommandLine options) throws BadArgumentsException, SQLException, ClassNotFoundException, BadPercentageException {
 
         // TODO : No està implementat encara la lpògica per el mètode "-c" càlcul de phi i k i el paràmetre -n
-
-        if(!options.hasOption(ApplicationOptions.OPTION_VALIDATION) && !options.hasOption(ApplicationOptions.OPTION_TRAINING) && !options.hasOption(ApplicationOptions.OPTION_DATABASE))
-            throw new BadArgumentsException("No option selected. ");
-
-        if (options.hasOption(ApplicationOptions.OPTION_TRAINING) && !options.hasOption(ApplicationOptions.OPTION_HAM) && !options.hasOption(ApplicationOptions.OPTION_SPAM))
-            throw new BadArgumentsException("To train database from Directory files must include arguments ham or spam [-h | -s].");
-
-        if(options.hasOption(ApplicationOptions.OPTION_TRAINING) && options.hasOption(ApplicationOptions.OPTION_HAM) && options.hasOption(ApplicationOptions.OPTION_SPAM))
-            throw new BadArgumentsException("To train database from Directory files only one value for ham or spam must be included [-h | -s].");
-
-        if(options.hasOption(ApplicationOptions.OPTION_DATABASE)) {
-            // En aquest cas com que la base de dades que estem carregant des d'un fitxer ja conté totes les taules no cal que distingim entre ham o spam
-            System.out.println("## TODO : Actualitzem la bd amb una altre bd anomenada : " + options.getOptionValue(ApplicationOptions.OPTION_DATABASE));
+        if(options.hasOption(ApplicationOptions.OPTION_COMPUTE)){
+            compute(options);
         }
+        else {
+            if(!options.hasOption(ApplicationOptions.OPTION_VALIDATION) && !options.hasOption(ApplicationOptions.OPTION_TRAINING) && !options.hasOption(ApplicationOptions.OPTION_DATABASE))
+                throw new BadArgumentsException("No option selected. ");
 
+            if (options.hasOption(ApplicationOptions.OPTION_TRAINING) && !options.hasOption(ApplicationOptions.OPTION_HAM) && !options.hasOption(ApplicationOptions.OPTION_SPAM))
+                throw new BadArgumentsException("To train database from Directory files must include arguments ham or spam [-h | -s].");
 
-        if(options.hasOption(ApplicationOptions.OPTION_TRAINING)) {
-            Trainer trainer = new Trainer();
-            if(options.hasOption(ApplicationOptions.OPTION_HAM)) {
-                System.out.println("## TODO : Actualitzem la bd amb un directori de mails anomenat : \"" + options.getOptionValue(ApplicationOptions.OPTION_TRAINING) + "\" sabent que és ham");
+            if(options.hasOption(ApplicationOptions.OPTION_TRAINING) && options.hasOption(ApplicationOptions.OPTION_HAM) && options.hasOption(ApplicationOptions.OPTION_SPAM))
+                throw new BadArgumentsException("To train database from Directory files only one value for ham or spam must be included [-h | -s].");
 
-                trainer.train(  ApplicationOptions.getTableFromParameter(ApplicationOptions.OPTION_HAM),
-                                new DirectoryMailReader(options.getOptionValue(ApplicationOptions.OPTION_TRAINING)),
-                                new StanfordCoreNLPFilter());
-
-            }
-            else{
-
-                System.out.println("## TODO : Actualitzem la bd amb un directori de mails anomenat : \"" + options.getOptionValue(ApplicationOptions.OPTION_TRAINING) + "\" sabent que és spam");
-
-                trainer.train(  ApplicationOptions.getTableFromParameter(ApplicationOptions.OPTION_SPAM),
-                                new DirectoryMailReader(options.getOptionValue(ApplicationOptions.OPTION_TRAINING)),
-                                new StanfordCoreNLPFilter());
+            if(options.hasOption(ApplicationOptions.OPTION_DATABASE)) {
+                // En aquest cas com que la base de dades que estem carregant des d'un fitxer ja conté totes les taules no cal que distingim entre ham o spam
+                System.out.println("## TODO : Actualitzem la bd amb una altre bd anomenada : " + options.getOptionValue(ApplicationOptions.OPTION_DATABASE));
             }
 
-        }
 
-        if(options.hasOption(ApplicationOptions.OPTION_VALIDATION)){
-            System.out.println("## TODO : Llencem el procés de validació amb el directori ." + options.getOptionValue(ApplicationOptions.OPTION_VALIDATION));
-        }
+            if(options.hasOption(ApplicationOptions.OPTION_TRAINING)) {
+                Trainer trainer = new Trainer();
+                if(options.hasOption(ApplicationOptions.OPTION_HAM)) {
+                    System.out.println("## TODO : Actualitzem la bd amb un directori de mails anomenat : \"" + options.getOptionValue(ApplicationOptions.OPTION_TRAINING) + "\" sabent que és ham");
 
-        // Persistim els canvis a la base de dades local sí o sí
-        if(options.hasOption(ApplicationOptions.OPTION_PERSIST)){
-            System.out.println("## TODO : Peristim la base de dades final al fitxer :" + options.getOptionValue(ApplicationOptions.OPTION_PERSIST));
+                    trainer.train(  ApplicationOptions.getTableFromParameter(ApplicationOptions.OPTION_HAM),
+                            new DirectoryMailReader(options.getOptionValue(ApplicationOptions.OPTION_TRAINING)),
+                            new StanfordCoreNLPFilter());
+
+                }
+                else{
+
+                    System.out.println("## TODO : Actualitzem la bd amb un directori de mails anomenat : \"" + options.getOptionValue(ApplicationOptions.OPTION_TRAINING) + "\" sabent que és spam");
+
+                    trainer.train(  ApplicationOptions.getTableFromParameter(ApplicationOptions.OPTION_SPAM),
+                            new DirectoryMailReader(options.getOptionValue(ApplicationOptions.OPTION_TRAINING)),
+                            new StanfordCoreNLPFilter());
+                }
+
+            }
+
+            if(options.hasOption(ApplicationOptions.OPTION_VALIDATION)){
+                System.out.println("## TODO : Llencem el procés de validació amb el directori ." + options.getOptionValue(ApplicationOptions.OPTION_VALIDATION));
+            }
+
+            // Persistim els canvis a la base de dades local sí o sí
+            if(options.hasOption(ApplicationOptions.OPTION_PERSIST)){
+                System.out.println("## TODO : Peristim la base de dades final al fitxer :" + options.getOptionValue(ApplicationOptions.OPTION_PERSIST));
+            }
         }
 
     }
 
+    /**
+     * Mètode per calcular la phi i la k
+     *
+     * Si no hi ha nombre d'iteracions només ho farà un sol cop.
+     * Per l'ordre següent es realitza la lectura de spam i després de ham dels directoris.
+     * @param options les opcions on hi ha els directoris spam i ham i el nombre de iteracions que ha de realitzar
+     */
+    public static void compute(CommandLine options) throws BadArgumentsException, BadPercentageException {
+
+        int iterations = 1;
+        if(options.hasOption(ApplicationOptions.OPTION_COMPUTATIONS_NUMBER)){
+            iterations = Integer.valueOf(options.getOptionValue(ApplicationOptions.OPTION_COMPUTATIONS_NUMBER));
+        }
+
+        // Llegim els directoris per spam i ham
+        String[] dirs = options.getOptionValues(ApplicationOptions.OPTION_COMPUTE);
+
+        // Validem l'existència dels dos fitxers.
+        if(!(dirs.length > 1 && dirs.length < 3)) throw new BadArgumentsException("Els directoris que s'han passat no son correctes per la opció -c");
+        String spamDir = dirs[0];
+        String hamDir = dirs[1];
+
+        // A la documentació marca que el directori spam primer i després el directori ham peró per prevenció fem un petit check que ens ho validi amb el nom del directori per no corrompir la BD.
+        if(spamDir.toLowerCase().indexOf("ham") > 0 || hamDir.toLowerCase().indexOf("spam") > 0) throw new BadArgumentsException("Comprova que el directori spam va primer i el ham va segon -c");
+
+        Reader spamReader = new DirectoryMailReader(spamDir);
+        Reader hamReader = new DirectoryMailReader(hamDir);
+
+        int phi, k;
+
+        /**
+         * Per cada una de les iteracions demanades :
+         * 1. Generem nombre aleatòri per el percentatge de correus que discriminarà dins del rang entre 5 i 15.
+         * 2. Generem nombres aleatoris per phi i k.
+         */
+        for(int count = 0; count < iterations; count++){
+            int percentage = ThreadLocalRandom.current().nextInt(MIN_PERC, MAX_PERC + 1);
+            // TODO : S'ha de fer el generador de phi i k amb high climbing.
+
+            KFoldCrossValidationSelection selection = new KFoldCrossValidationSelection(spamReader, hamReader, percentage, random);
+            // TODO : a selection hi ha els mails carregats sense filtrar.
+            // TODO : Primer s'ha d'accedir a getSpam i getHam i després accedir a getUnknown.
+
+            // TODO : S'ha de llençar la validació , rebre els resultats ok i els resultats bad
+            // TODO : S'ha d'inserir la fila de l'execució amb la phi i la k generades.
+        }
+
+    }
 
     public static void main(String [] args) {
         random = new Random();
@@ -95,7 +155,7 @@ public class Application  {
             System.out.println(Database.getInstance().select(Database.Table.HAM));
             System.out.println(Database.getInstance().select(Database.Table.SPAM));
 
-        } catch (BadArgumentsException e) {
+        } catch (CustomException e) {
             System.err.println(e.getCustomMessage());
             System.err.println("------------------------------------------------------------------------------");
             System.err.println(e.getMessage());

--- a/src/spamizer/Application.java
+++ b/src/spamizer/Application.java
@@ -47,20 +47,13 @@ public class Application  {
         if(options.hasOption(ApplicationOptions.OPTION_DATABASE)) {
             // En aquest cas com que la base de dades que estem carregant des d'un fitxer ja conté totes les taules no cal que distingim entre ham o spam
             System.out.println("## TODO : Actualitzem la bd amb una altre bd anomenada : " + options.getOptionValue(ApplicationOptions.OPTION_DATABASE));
-
-
-
-            /*hamReader = new DirectoryMailReader(hamDirectoryPath);
-            spamReader = new DirectoryMailReader(spamDirectoryPath);
-            this.hamDirectoryPath = hamDirectoryPath;
-            this.spamDirectoryPath = spamDirectoryPath;*/
         }
 
 
         if(options.hasOption(ApplicationOptions.OPTION_TRAINING)) {
             Trainer trainer = new Trainer();
             if(options.hasOption(ApplicationOptions.OPTION_HAM)) {
-                System.out.println("## TODO : Actualitzem la bd amb un directori de mails anomenat : \"" + options.getOptionValue(ApplicationOptions.OPTION_TRAINING) + "\" saben que és ham");
+                System.out.println("## TODO : Actualitzem la bd amb un directori de mails anomenat : \"" + options.getOptionValue(ApplicationOptions.OPTION_TRAINING) + "\" sabent que és ham");
 
                 trainer.train(  ApplicationOptions.getTableFromParameter(ApplicationOptions.OPTION_HAM),
                                 new DirectoryMailReader(options.getOptionValue(ApplicationOptions.OPTION_TRAINING)),
@@ -69,7 +62,7 @@ public class Application  {
             }
             else{
 
-                System.out.println("## TODO : Actualitzem la bd amb un directori de mails anomenat : \"" + options.getOptionValue(ApplicationOptions.OPTION_TRAINING) + "\" saben que és spam");
+                System.out.println("## TODO : Actualitzem la bd amb un directori de mails anomenat : \"" + options.getOptionValue(ApplicationOptions.OPTION_TRAINING) + "\" sabent que és spam");
 
                 trainer.train(  ApplicationOptions.getTableFromParameter(ApplicationOptions.OPTION_SPAM),
                                 new DirectoryMailReader(options.getOptionValue(ApplicationOptions.OPTION_TRAINING)),

--- a/src/spamizer/MLCore/DirectoryMailReader.java
+++ b/src/spamizer/MLCore/DirectoryMailReader.java
@@ -28,7 +28,7 @@ public class DirectoryMailReader implements Reader {
      * @return list of mails.
      */
     @Override
-    public Collection<Mail> read()
+    public Collection<Mail> read(boolean isSpam)
     {
         List<Mail> mails = new ArrayList<Mail>();
         File folder = new File(folderPath);
@@ -49,7 +49,7 @@ public class DirectoryMailReader implements Reader {
                         lowerData=lowerData.replace("subject:","");
                     }
                     String body = lowerData.replace(subject,"");
-                    Mail m = new Mail(subject,body);
+                    Mail m = new Mail(subject,body, isSpam);
                     mails.add(m);
                 }
                 catch(Exception e){

--- a/src/spamizer/MLCore/DirectoryMailReader.java
+++ b/src/spamizer/MLCore/DirectoryMailReader.java
@@ -1,5 +1,7 @@
 package spamizer.MLCore;
 
+import spamizer.interfaces.Reader;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -11,19 +13,22 @@ import java.util.List;
 
 import static jdk.nashorn.internal.objects.NativeString.toLowerCase;
 
-public class DirectoryMailReader implements Reader{
-    List<Mail> mails;
-    List<String> splitter;
+public class DirectoryMailReader implements Reader {
 
-    public DirectoryMailReader(){
+    String folderPath;
+
+    public DirectoryMailReader(String folderPath){
+        if(System.getProperty("os.name").toLowerCase().indexOf("win") >= 0)
+            this.folderPath = folderPath + "\\";
+        else
+            this.folderPath = folderPath + "/";
     }
     /**
      * Function to read all files from folder in folderPath, and return a list of Mails.
-     * @param folderPath folder path.
      * @return list of mails.
      */
     @Override
-    public Collection<Mail> read(String folderPath)
+    public Collection<Mail> read()
     {
         List<Mail> mails = new ArrayList<Mail>();
         File folder = new File(folderPath);
@@ -36,7 +41,7 @@ public class DirectoryMailReader implements Reader{
                 BufferedReader br = null;
                 try {
                     file = new File (listOfFiles[i].getName());
-                    String data = new String(Files.readAllBytes(Paths.get(folderPath+"\\"+file)));
+                    String data = new String(Files.readAllBytes(Paths.get(folderPath + file)));
                     String lowerData = toLowerCase(data).replaceAll("cc|to|from", "");
                     String subject = "";
                     if(lowerData.indexOf("subject:")!=-1){

--- a/src/spamizer/MLCore/KFoldCrossValidationSelection.java
+++ b/src/spamizer/MLCore/KFoldCrossValidationSelection.java
@@ -1,0 +1,28 @@
+package spamizer.MLCore;
+
+import spamizer.interfaces.Reader;
+
+import java.util.Collection;
+import java.util.Queue;
+
+public class KFoldCrossValidationSelection {
+
+
+    private Reader reader;
+    private Queue<Mail> spam;
+    private Queue<Mail> ham;
+    private Queue<Mail> unknown;
+
+    public KFoldCrossValidationSelection(Reader reader){
+        this.reader = reader;
+    }
+
+    public void read(){
+        Collection<Mail> mails = reader.read();
+    }
+
+
+
+
+
+}

--- a/src/spamizer/MLCore/KFoldCrossValidationSelection.java
+++ b/src/spamizer/MLCore/KFoldCrossValidationSelection.java
@@ -1,6 +1,7 @@
 package spamizer.MLCore;
 
 import spamizer.exceptions.BadPercentageException;
+import spamizer.interfaces.Filter;
 import spamizer.interfaces.Reader;
 
 import java.util.*;

--- a/src/spamizer/MLCore/KFoldCrossValidationSelection.java
+++ b/src/spamizer/MLCore/KFoldCrossValidationSelection.java
@@ -39,7 +39,7 @@ public class KFoldCrossValidationSelection {
      * @return Una collecció amb els correus considerats spam
      */
     public Collection<Mail> getSpam(){
-        return getFilteredByPercentage(spamReader.read());
+        return getFilteredByPercentage(spamReader.read(true));
     }
 
     /**
@@ -47,7 +47,7 @@ public class KFoldCrossValidationSelection {
      * @return Una collecció amb els correus considerats ham
      */
     public Collection<Mail> getHam(){
-        return getFilteredByPercentage(hamReader.read());
+        return getFilteredByPercentage(hamReader.read(false));
     }
 
     /**

--- a/src/spamizer/MLCore/KFoldCrossValidationSelection.java
+++ b/src/spamizer/MLCore/KFoldCrossValidationSelection.java
@@ -1,25 +1,90 @@
 package spamizer.MLCore;
 
+import spamizer.exceptions.BadPercentageException;
 import spamizer.interfaces.Reader;
 
-import java.util.Collection;
-import java.util.Queue;
+import java.util.*;
+import java.util.concurrent.LinkedBlockingQueue;
 
 public class KFoldCrossValidationSelection {
 
-
-    private Reader reader;
-    private Queue<Mail> spam;
-    private Queue<Mail> ham;
     private Queue<Mail> unknown;
+    private int percentage;
+    private Random random;
 
-    public KFoldCrossValidationSelection(Reader reader){
-        this.reader = reader;
+    private Reader spamReader;
+    private Reader hamReader;
+
+    /**
+     *
+     * @param spamReader El lector de spam (instanciat amb la font de dades dels correus spam)
+     * @param hamReader El lector de ham (instanciat amb la font de dades dels correus ham)
+     * @param percentage El percentatge de mails que s'utilitzaran per ser discriminats com spam o ham (el valor petit)
+     * @param random Una llavor per generar nombres aleatòris.
+     * @throws BadPercentageException
+     */
+    public KFoldCrossValidationSelection(Reader spamReader, Reader hamReader, int percentage, Random random) throws BadPercentageException {
+        if(percentage < 0 || percentage > 100)
+            throw new BadPercentageException("Value " + percentage + " is not correct, must be between 0 and 100");
+        this.spamReader = spamReader;
+        this.hamReader = hamReader;
+        this.percentage = percentage;
+        this.random = random;
+        unknown = new PriorityQueue<>();
     }
 
-    public void read(){
-        Collection<Mail> mails = reader.read();
+    /**
+     * Selecciona aleatòriament els correus de la font de dades spam
+     * @return Una collecció amb els correus considerats spam
+     */
+    public Collection<Mail> getSpam(){
+        return getFilteredByPercentage(spamReader.read());
     }
+
+    /**
+     * Selecciona aleatòriament els correus de la font de dades ham
+     * @return Una collecció amb els correus considerats ham
+     */
+    public Collection<Mail> getHam(){
+        return getFilteredByPercentage(hamReader.read());
+    }
+
+    /**
+     * PRE : --
+     * POST : LLista de correus que no s'han filtrat.
+     * @return un llistat aleatori de correus que no han sigut filtrats.
+     */
+    public Collection<Mail> getUnknown(){
+        // En cas que no s'hagi accedit a cap dels dos mètodes forcem per que hi accedeixi.
+        if(unknown.size() == 0){
+            Collection<Mail> spam = getSpam();
+            Collection<Mail> ham = getHam();
+        }
+        return unknown;
+    }
+
+    /**
+     * Aplica el percentatge de filtre per les lectures.
+     * @param mails Font de dades
+     * @return Retorna la collecció de correus que no s'ha discriminat
+     */
+    private Collection<Mail> getFilteredByPercentage(Collection<Mail> mails){
+        Iterator<Mail> iterator = mails.iterator();
+        LinkedList<Mail> filtered = new LinkedList<>();
+        while (iterator.hasNext()){
+            int randValue = (Math.abs(random.nextInt()) % 101); // Hi ha 101 possibilitats de 0 - 100 en percentatges.
+            if(randValue <= percentage){ // Per ser exactes és +=
+                unknown.add(iterator.next());
+            }
+            else {
+                filtered.add(iterator.next());
+            }
+        }
+        return filtered;
+    }
+
+
+
 
 
 

--- a/src/spamizer/MLCore/Mail.java
+++ b/src/spamizer/MLCore/Mail.java
@@ -12,10 +12,12 @@ public class Mail {
     private String subject;
     private String body;
     private Filter filter;
+    private Boolean isSpam;
 
-    public Mail(String subject,String body){
+    public Mail(String subject,String body, boolean isSpam){
         this.subject = subject;
         this.body = body;
+        this.isSpam = isSpam;
         this.filter = new StanfordCoreNLPFilter();
     }
     /**
@@ -30,7 +32,6 @@ public class Mail {
      * @return
      */
     public HashMap<String,Integer> getBodyMail(){
-
         return filter.filterText(this.body);
     }
 
@@ -51,5 +52,9 @@ public class Mail {
 
     public void setFilter(Filter filter){
         this.filter = filter;
+    }
+
+    public Boolean getSpam() {
+        return isSpam;
     }
 }

--- a/src/spamizer/MLCore/Mail.java
+++ b/src/spamizer/MLCore/Mail.java
@@ -1,5 +1,7 @@
 package spamizer.MLCore;
 
+import spamizer.interfaces.Filter;
+
 import java.util.HashMap;
 
 /**

--- a/src/spamizer/MLCore/NaiveBayes.java
+++ b/src/spamizer/MLCore/NaiveBayes.java
@@ -1,10 +1,11 @@
 package spamizer.MLCore;
 
 import spamizer.entity.Database;
+import spamizer.interfaces.Method;
 
 import java.util.Collection;
 
-public class NaiveBayes implements  Method {
+public class NaiveBayes implements Method {
 
     @Override
     public ProbabylityResult getProbabilities(Database database, Collection<String> words) {

--- a/src/spamizer/MLCore/Reader.java
+++ b/src/spamizer/MLCore/Reader.java
@@ -1,8 +1,0 @@
-package spamizer.MLCore;
-
-import java.util.Collection;
-
-public interface Reader {
-
-    public Collection<Mail> read(String pathFolder);
-}

--- a/src/spamizer/MLCore/StanfordCoreNLPFilter.java
+++ b/src/spamizer/MLCore/StanfordCoreNLPFilter.java
@@ -5,6 +5,7 @@ import edu.stanford.nlp.ling.CoreAnnotations;
 import edu.stanford.nlp.ling.CoreLabel;
 import edu.stanford.nlp.pipeline.*;
 import edu.stanford.nlp.util.CoreMap;
+import spamizer.interfaces.Filter;
 
 import java.util.*;
 

--- a/src/spamizer/MLCore/Trainer.java
+++ b/src/spamizer/MLCore/Trainer.java
@@ -17,7 +17,7 @@ public class Trainer {
     }
 
     public void train (Database.Table table, Reader reader, Filter filter) throws SQLException {
-        Collection<Mail> mailsFiltrats = reader.read();
+        Collection<Mail> mailsFiltrats = reader.read(Database.Table.SPAM == table);
         HashMap<String,Integer> mapinsertMailFiltered = new HashMap<>();
         int counter = 1;
         for (Mail m : mailsFiltrats)

--- a/src/spamizer/MLCore/Trainer.java
+++ b/src/spamizer/MLCore/Trainer.java
@@ -1,6 +1,8 @@
 package spamizer.MLCore;
 
 import spamizer.entity.Database;
+import spamizer.interfaces.Filter;
+import spamizer.interfaces.Reader;
 
 import java.sql.SQLException;
 import java.util.Collection;
@@ -8,38 +10,28 @@ import java.util.HashMap;
 
 public class Trainer {
 
-    protected Reader reader;
-    protected String hamDirectoryPath;
-    protected String spamDirectoryPath;
     protected Database memoryDataBase;
 
-    public Trainer(String hamDirectoryPath, String spamDirectoryPath) throws SQLException, ClassNotFoundException {
-        reader = new DirectoryMailReader();
-        //si el constructor no pot inicialitzar la DB fa un Throw cap a fora.
+    public Trainer() throws SQLException, ClassNotFoundException {
         memoryDataBase = Database.getInstance();
-        this.hamDirectoryPath = hamDirectoryPath;
-        this.spamDirectoryPath = spamDirectoryPath;
-
     }
 
-    public void trainning () throws SQLException {
-        trainningSpam(Database.Table.SPAM,spamDirectoryPath);
-    }
-    private void trainningSpam(Database.Table table,String pathDirectory) throws SQLException {
-        Collection<Mail> mailsFiltrats = reader.read(pathDirectory);
+    public void train (Database.Table table, Reader reader, Filter filter) throws SQLException {
+        Collection<Mail> mailsFiltrats = reader.read();
         HashMap<String,Integer> mapinsertMailFiltered = new HashMap<>();
+        int counter = 1;
         for (Mail m : mailsFiltrats)
         {
-            m.setFilter(new StanfordCoreNLPFilter());
+            m.setFilter(filter);
             if(!mapinsertMailFiltered.isEmpty()){
                 m.getBodyMail().forEach(
                         (key, value) -> mapinsertMailFiltered.merge( key, value, (v1, v2) -> v1+v2));
             }else{
                 mapinsertMailFiltered.putAll(m.getBodyMail());
             }
-
+            System.out.println(counter);
+            counter++;
         }
-        System.out.println(mapinsertMailFiltered);
         memoryDataBase.insertOrUpdate(table,mapinsertMailFiltered);
     }
 

--- a/src/spamizer/MLCore/Validator.java
+++ b/src/spamizer/MLCore/Validator.java
@@ -1,5 +1,7 @@
 package spamizer.MLCore;
 
+import spamizer.interfaces.Method;
+
 import java.sql.SQLException;
 
 public class Validator extends Trainer {
@@ -7,7 +9,7 @@ public class Validator extends Trainer {
     private Method classifcationMethod;
 
     public Validator(Method classifcationMethod) throws SQLException, ClassNotFoundException {
-        super("","");
+        super();
         this.classifcationMethod = classifcationMethod;
     }
 }

--- a/src/spamizer/configurations/ApplicationOptions.java
+++ b/src/spamizer/configurations/ApplicationOptions.java
@@ -27,7 +27,7 @@ public class ApplicationOptions {
         options.addOption(new Option(OPTION_DATABASE, true, "Database file with other execution data, this or directory training argument must be present"));
         options.addOption(new Option(OPTION_VALIDATION, true, "Directory where validation mails in txt are stored"));
         options.addOption(new Option(OPTION_PERSIST, true, "Directory where final database will be persisted"));
-        options.addOption(new Option(OPTION_COMPUTE, true, "Receives 2 parameters, A directory with spam mails and a directory with ham mails. "
+        options.addOption(new Option(OPTION_COMPUTE, true, "Usage : -c <spamDir> <hamDir> [-n <int>] \nReceives 2 parameters, A directory with spam mails and a directory with ham mails. "
                 + "A calculation for values phi and k will be done using a selection for the mails set. The selection will be k-fold cross-validation and the heuristic method used to calculate phi and k values will be High Climbing with random restarts"));
         options.addOption(new Option(OPTION_COMPUTATIONS_NUMBER, true, "The number of iterations for -c mode execution."));
     }

--- a/src/spamizer/configurations/ApplicationOptions.java
+++ b/src/spamizer/configurations/ApplicationOptions.java
@@ -2,6 +2,8 @@ package spamizer.configurations;
 
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
+import org.omg.CORBA.DATA_CONVERSION;
+import spamizer.entity.Database;
 
 public class ApplicationOptions {
 
@@ -29,6 +31,14 @@ public class ApplicationOptions {
                 + "A calculation for values phi and k will be done using a selection for the mails set. The selection will be k-fold cross-validation and the heuristic method used to calculate phi and k values will be High Climbing with random restarts"));
         options.addOption(new Option(OPTION_COMPUTATIONS_NUMBER, true, "The number of iterations for -c mode execution."));
     }
+
+    public static Database.Table getTableFromParameter(String param){
+        if(param == OPTION_SPAM) return Database.Table.SPAM;
+        else if(param == OPTION_HAM) return Database.Table.HAM;
+        // Està fet expressament per què falli.
+        else return null;
+    }
+
 
     public Options getOptions(){
         return options;

--- a/src/spamizer/exceptions/BadArgumentsException.java
+++ b/src/spamizer/exceptions/BadArgumentsException.java
@@ -1,15 +1,9 @@
 package spamizer.exceptions;
 
-public class BadArgumentsException extends Exception {
+public class BadArgumentsException extends CustomException {
 
-    private String message;
 
-    public BadArgumentsException(String message){
-        this.message = message;
+    public BadArgumentsException(String message) {
+        super(message);
     }
-
-    public String getCustomMessage(){
-        return this.message;
-    }
-
 }

--- a/src/spamizer/exceptions/BadPercentageException.java
+++ b/src/spamizer/exceptions/BadPercentageException.java
@@ -1,0 +1,14 @@
+package spamizer.exceptions;
+
+public class BadPercentageException extends Exception {
+
+    private String message;
+
+    public BadPercentageException(String message){
+        this.message = message;
+    }
+
+    public String getCustomMessage(){
+        return this.message;
+    }
+}

--- a/src/spamizer/exceptions/BadPercentageException.java
+++ b/src/spamizer/exceptions/BadPercentageException.java
@@ -1,14 +1,9 @@
 package spamizer.exceptions;
 
-public class BadPercentageException extends Exception {
+public class BadPercentageException extends CustomException {
 
-    private String message;
 
-    public BadPercentageException(String message){
-        this.message = message;
-    }
-
-    public String getCustomMessage(){
-        return this.message;
+    public BadPercentageException(String message) {
+        super(message);
     }
 }

--- a/src/spamizer/exceptions/CustomException.java
+++ b/src/spamizer/exceptions/CustomException.java
@@ -1,0 +1,15 @@
+package spamizer.exceptions;
+
+public class CustomException extends Exception{
+
+    private String message;
+
+    public CustomException(String message){
+        this.message = message;
+    }
+
+    public String getCustomMessage(){
+        return this.message;
+    }
+
+}

--- a/src/spamizer/interfaces/Filter.java
+++ b/src/spamizer/interfaces/Filter.java
@@ -1,4 +1,4 @@
-package spamizer.MLCore;
+package spamizer.interfaces;
 
 import java.util.HashMap;
 public interface Filter {

--- a/src/spamizer/interfaces/Method.java
+++ b/src/spamizer/interfaces/Method.java
@@ -1,5 +1,6 @@
-package spamizer.MLCore;
+package spamizer.interfaces;
 
+import spamizer.MLCore.ProbabylityResult;
 import spamizer.entity.Database;
 
 import java.util.Collection;

--- a/src/spamizer/interfaces/Reader.java
+++ b/src/spamizer/interfaces/Reader.java
@@ -1,0 +1,10 @@
+package spamizer.interfaces;
+
+import spamizer.MLCore.Mail;
+
+import java.util.Collection;
+
+public interface Reader {
+
+    public Collection<Mail> read();
+}

--- a/src/spamizer/interfaces/Reader.java
+++ b/src/spamizer/interfaces/Reader.java
@@ -6,5 +6,5 @@ import java.util.Collection;
 
 public interface Reader {
 
-    public Collection<Mail> read();
+    public Collection<Mail> read(boolean isSpam);
 }


### PR DESCRIPTION
Training amb les opcions : 

- -h -t "directori"
- -s -t "directori"

S'ha modificat una mica el codi del reader i s'hi ha afegit la casuística dels paths quan és per windows o qualsevol altre sistema operatiu. 

Fa servir la inserció amb els mots filtrats amb el lemmatitzador de la llibreria stanford. 

He detectat que la llibreria no entén de caràcters raros, s'hauria de pulir la codificació dels correus o intentar llegir-los d'alguna manera que no dongués tants de warnings. Hi ha mails que no estan en utf-8. 

La inserció la fa bé i el map el crea bé tant per la taula de spam com per la de ham. 
